### PR TITLE
Take account of custom_field for form-originating payments

### DIFF
--- a/src/app/api/webhooks/paystack/route.ts
+++ b/src/app/api/webhooks/paystack/route.ts
@@ -15,6 +15,11 @@ interface PaystackWebhookEvent {
     paid_at: string; // UTC date string
     subaccount: Record<string, unknown>;
     metadata: {
+      custom_fields: {
+        display_name: string;
+        variable_name: string;
+        value: string;
+      }[];
       unitId: string;
     };
   };
@@ -40,7 +45,7 @@ export async function POST(req: Request) {
     // Will handle other events in the future
     return defaultResponse;
   }
-
+  console.log(body.data.metadata.custom_fields);
   await handleChargeSuccess(body.data);
   return defaultResponse;
 }
@@ -51,60 +56,73 @@ export async function POST(req: Request) {
  * @param data The data from the `charge.success` webhook event
  */
 async function handleChargeSuccess(data: PaystackWebhookEvent["data"]) {
-  try {
-    await db.transaction(async (tx) => {
-      // Get unit and tenant details
-      const unitResult = await tx
-        .select({ id: unit.id, occupied: unit.occupied })
-        .from(unit)
-        .where(eq(unit.id, data.metadata.unitId));
-
-      const currentUnit = unitResult[0];
-      if (!currentUnit) {
-        throw new Error("Unit not found: " + data.metadata.unitId);
-      }
-
-      if (currentUnit.occupied === false) {
-        throw new Error("Unit is not occupied: " + currentUnit.id);
-      }
-
-      const tenantResult = await tx
-        .select()
-        .from(tenant)
-        .where(eq(tenant.unitId, currentUnit.id))
-        .limit(1);
-
-      const currentTenant = tenantResult[0];
-      if (!currentTenant) {
-        throw new Error("Tenant not found: " + currentUnit.id);
-      }
-
-      // Paystack uses subunits, so we divide the amount by 100 to get the actual amount
-      // Currently, the type of amount is `integer` in the schema, hence the rounding,
-      // but it should be of type `decimal` in the future
-      // to avoid rounding errors.
-      const amount = Math.round(data.amount / 100);
-
-      // Insert payment record
-      await tx.insert(payment).values({
-        referenceNumber: data.reference,
-        amount: amount,
-        paymentMethod: "mpesa",
-        paidAt: new Date(data.paid_at),
-        paymentReference: data.reference,
-        unitId: currentUnit.id,
-        tenantId: currentTenant.id,
-      });
-
-      // Update tenant's cumulative rent paid
-      await tx
-        .update(tenant)
-        .set({
-          cumulativeRentPaid: currentTenant.cumulativeRentPaid + amount,
-        })
-        .where(eq(tenant.id, currentTenant.id));
-    });
-  } catch (error) {
-    console.error("Error handling charge success:", error);
+  let unitId: string;
+  if (data.metadata.custom_fields.length === 1) {
+    unitId = data.metadata.custom_fields[0]!.value;
+  } else if (data.metadata.unitId) {
+    unitId = data.metadata.unitId;
+  } else {
+    throw new Error("Unit ID not found in metadata");
   }
+
+  updateDbOnRentPayment(unitId, data).catch((err) => {
+    console.error("Error updating database on rent payment:", err);
+  });
+}
+
+async function updateDbOnRentPayment(
+  unitId: string,
+  data: PaystackWebhookEvent["data"],
+) {
+  await db.transaction(async (tx) => {
+    const unitResult = await tx
+      .select({ id: unit.id, occupied: unit.occupied })
+      .from(unit)
+      .where(eq(unit.id, unitId));
+
+    const currentUnit = unitResult[0];
+    if (!currentUnit) {
+      throw new Error("Unit not found: " + data.metadata.unitId);
+    }
+
+    if (currentUnit.occupied === false) {
+      throw new Error("Unit is not occupied: " + currentUnit.id);
+    }
+
+    const tenantResult = await tx
+      .select()
+      .from(tenant)
+      .where(eq(tenant.unitId, currentUnit.id))
+      .limit(1);
+
+    const currentTenant = tenantResult[0];
+    if (!currentTenant) {
+      throw new Error("Tenant not found: " + currentUnit.id);
+    }
+
+    // Paystack uses subunits, so we divide the amount by 100 to get the actual amount
+    // Currently, the type of amount is `integer` in the schema, hence the rounding,
+    // but it should be of type `decimal` in the future
+    // to avoid rounding errors.
+    const amount = Math.round(data.amount / 100);
+
+    // Insert payment record
+    await tx.insert(payment).values({
+      referenceNumber: data.reference,
+      amount: amount,
+      paymentMethod: "mpesa",
+      paidAt: new Date(data.paid_at),
+      paymentReference: data.reference,
+      unitId: currentUnit.id,
+      tenantId: currentTenant.id,
+    });
+
+    // Update tenant's cumulative rent paid
+    await tx
+      .update(tenant)
+      .set({
+        cumulativeRentPaid: currentTenant.cumulativeRentPaid + amount,
+      })
+      .where(eq(tenant.id, currentTenant.id));
+  });
 }

--- a/src/app/api/webhooks/paystack/route.ts
+++ b/src/app/api/webhooks/paystack/route.ts
@@ -65,7 +65,7 @@ async function handleChargeSuccess(data: PaystackWebhookEvent["data"]) {
     throw new Error("Unit ID not found in metadata");
   }
 
-  updateDbOnRentPayment(unitId, data).catch((err) => {
+  await updateDbOnRentPayment(unitId, data).catch((err) => {
     console.error("Error updating database on rent payment:", err);
   });
 }

--- a/src/app/api/webhooks/paystack/route.ts
+++ b/src/app/api/webhooks/paystack/route.ts
@@ -57,7 +57,7 @@ export async function POST(req: Request) {
  */
 async function handleChargeSuccess(data: PaystackWebhookEvent["data"]) {
   let unitId: string;
-  if (data.metadata.custom_fields.length === 1) {
+  if (data.metadata.custom_fields?.length === 1) {
     unitId = data.metadata.custom_fields[0]!.value;
   } else if (data.metadata.unitId) {
     unitId = data.metadata.unitId;


### PR DESCRIPTION
While creating a Paystack payment page, extra information is added into the `data.metadata.custom_fields` array. This is where the unit id (the information required to make a payment) will be stored in the payload returned by the webhook call made by Paystack on a successful charge.

The code now takes accounts of this, and extracts the unit id, depending on the source of the payment (USSD or Paystack Payment).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of payment webhook events to more reliably extract and process unit information from incoming data.
- **Refactor**
	- Streamlined the process for updating rent payments, enhancing error handling and reliability for webhook processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->