### PR TITLE
Add creation buttons to tenant and unit pages

### DIFF
--- a/src/app/(protected)/properties/[id]/tenants/new/page.tsx
+++ b/src/app/(protected)/properties/[id]/tenants/new/page.tsx
@@ -1,4 +1,5 @@
 import { AddTenantForm } from "~/components/forms/add-tenant-form";
+import { BackButton } from "~/components/ui/back-button";
 import { getUnits } from "~/server/actions/units";
 
 type Params = Promise<{ id: string }>;
@@ -9,6 +10,7 @@ export default async function AddTenantPage({ params }: { params: Params }) {
 
   return (
     <div>
+      <BackButton />
       <h1 className="my-4 text-2xl font-bold">Add Tenant</h1>
       <div className="max-w-xl">
         <AddTenantForm units={units} />

--- a/src/app/(protected)/properties/[id]/tenants/page.tsx
+++ b/src/app/(protected)/properties/[id]/tenants/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Plus } from "lucide-react";
 
 import { Button } from "~/components/ui/button";
 import { DataTable } from "~/components/ui/tables/data-table";
@@ -12,17 +13,17 @@ export default async function TenantsPage({ params }: { params: Params }) {
 
   const tenants = await getTenants(id);
 
-  if (tenants.length === 0) {
-    return (
-      <Link href={`/properties/${id}/tenants/new`}>
-        <Button>Add Tenant</Button>
-      </Link>
-    );
-  }
-
   return (
     <div>
-      <h1 className="my-4 text-2xl font-bold">Tenants</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="my-4 text-2xl font-bold">Tenants</h1>
+        <Button asChild>
+          <Link href={`/properties/${id}/tenants/new`}>
+            <Plus />
+            Add Tenant
+          </Link>
+        </Button>
+      </div>
       <DataTable
         columns={tenantTableColumns}
         data={tenants}

--- a/src/app/(protected)/properties/[id]/units/new/page.tsx
+++ b/src/app/(protected)/properties/[id]/units/new/page.tsx
@@ -1,4 +1,5 @@
 import { AddUnitForm } from "~/components/forms/add-unit-form";
+import { BackButton } from "~/components/ui/back-button";
 import { getUnitTypes } from "~/server/actions/units";
 
 type Params = Promise<{ id: string }>;
@@ -10,6 +11,7 @@ export default async function AddUnitPage({ params }: { params: Params }) {
 
   return (
     <div>
+      <BackButton />
       <h1 className="my-4 text-2xl font-bold">New Unit</h1>
       <div className="max-w-xs">
         <AddUnitForm unitTypes={unitTypes} propertyId={id} />

--- a/src/app/(protected)/properties/[id]/units/page.tsx
+++ b/src/app/(protected)/properties/[id]/units/page.tsx
@@ -1,3 +1,6 @@
+import Link from "next/link";
+import { Plus } from "lucide-react";
+
 import { Button } from "~/components/ui/button";
 import { DataTable } from "~/components/ui/tables/data-table";
 import { unitTableColumns } from "~/components/ui/tables/table-columns/units";
@@ -10,14 +13,17 @@ export default async function UnitsPage({ params }: { params: Params }) {
 
   const units = await getUnits(id);
 
-  if (units.length === 0) {
-    return <Button>Create Unit</Button>;
-  }
-
   return (
     <div>
-      <h1 className="my-4 text-2xl font-bold">Units</h1>
-      <div></div>
+      <div className="flex items-center justify-between">
+        <h1 className="my-4 text-2xl font-bold">Units</h1>
+        <Button asChild>
+          <Link href={`/properties/${id}/units/new`}>
+            <Plus />
+            Add Unit
+          </Link>
+        </Button>
+      </div>
       <DataTable
         columns={unitTableColumns}
         data={units}

--- a/src/components/ui/back-button.tsx
+++ b/src/components/ui/back-button.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { TooltipTrigger } from "@radix-ui/react-tooltip";
+import { ArrowLeft } from "lucide-react";
+
+import { Tooltip, TooltipContent } from "~/components/ui/tooltip";
+import { Button } from "./button";
+
+export function BackButton() {
+  const router = useRouter();
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="link"
+          onClick={() => router.back()}
+          className="cursor-pointer"
+        >
+          <ArrowLeft size={48} />
+          <span className="sr-only">Back</span>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Go back</TooltipContent>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
After the dashboard revamp, there's currently no way to access the pages for adding units and tenants. 

The fix was simple, just a button in the respective pages.

Also, I've added a back button component to the creation pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a Back button for easier navigation on the "Add Tenant" and "Add Unit" pages.
  - Added a consistent header with title and action button ("Add Tenant"/"Add Unit") on the Tenants and Units pages, displayed regardless of list content.
- **Style**
  - Improved layout and alignment of headers and action buttons for Tenants and Units pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->