### PR TITLE
refactor: create trpc router for paystack calls

### DIFF
--- a/src/app/(protected)/properties/new/layout.tsx
+++ b/src/app/(protected)/properties/new/layout.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { useState } from "react";
+import { UserButton } from "@clerk/nextjs";
 
 import {
   CreatePropertyFormContext,
   CreatePropertyFormDispatchContext,
   defaultContext,
 } from "~/components/forms/context";
+import { MaxWidthWrapper } from "~/components/max-width-wrapper";
+import { ModeToggle } from "~/components/mode-toggle";
 
 export default function Layout({
   children,
@@ -15,9 +18,14 @@ export default function Layout({
   return (
     <CreatePropertyFormContext value={values}>
       <CreatePropertyFormDispatchContext value={setValues}>
-        <div>
-          <h1 className="mb-8 text-xl">Create Property</h1>
-          {children}
+        <div className="flex min-h-screen flex-col items-center">
+          <MaxWidthWrapper className="flex-1">
+            <header className="bg-background sticky top-0 z-50 flex h-14 items-center justify-end space-x-4 px-4 lg:h-[60px]">
+              <UserButton />
+              <ModeToggle />
+            </header>
+            <main>{children}</main>
+          </MaxWidthWrapper>
         </div>
       </CreatePropertyFormDispatchContext>
     </CreatePropertyFormContext>

--- a/src/app/(protected)/properties/new/page.tsx
+++ b/src/app/(protected)/properties/new/page.tsx
@@ -1,14 +1,22 @@
 import { CreatePropertyForm } from "~/components/forms/create-property-form";
-import { fetchBanks } from "~/server/actions/properties";
+import ErrorPage from "~/components/pages/error";
+import { BackButton } from "~/components/ui/back-button";
+import { api } from "~/trpc/server";
 
-export default async function CreatePropertyPage() {
-  const banks = await fetchBanks();
+export const dynamic = "force-dynamic";
 
-  return (
-    <div>
-      <div className="max-w-xs">
+export default async function NewPropertyPage() {
+  try {
+    const banks = await api.paystack.fetchBanks();
+    return (
+      <div className="p-4 md:p-0">
+        <BackButton />
+        <h1 className="my-8 text-xl">Create Property</h1>
         <CreatePropertyForm banks={banks} />
       </div>
-    </div>
-  );
+    );
+  } catch (error) {
+    console.error("Error fetching banks:", error);
+    return <ErrorPage />;
+  }
 }

--- a/src/app/(protected)/properties/new/unit-types/page.tsx
+++ b/src/app/(protected)/properties/new/unit-types/page.tsx
@@ -8,6 +8,7 @@ import {
   CreateUnitTypeForm,
   UnitTypesTable,
 } from "~/components/forms/create-unit-type-form";
+import { BackButton } from "~/components/ui/back-button";
 import { Separator } from "~/components/ui/separator";
 
 export default function Page() {
@@ -24,7 +25,9 @@ export default function Page() {
   }, [router, bankCode, bankAccountNumber, propertyName]);
 
   return (
-    <div>
+    <div className="p-4">
+      <BackButton />
+      <h2 className="my-8 text-lg font-semibold">Unit Types</h2>
       <div className="grid gap-8 md:grid-cols-2">
         <UnitTypesTable unitTypes={unitTypes} />
         <Separator className="md:hidden" />

--- a/src/components/forms/create-unit-type-form.tsx
+++ b/src/components/forms/create-unit-type-form.tsx
@@ -201,34 +201,31 @@ export function UnitTypesTable({
     });
   }
   return (
-    <div>
-      <h2 className="text-lg font-semibold">Unit Types</h2>
-      <Table className="max-w-[500px]">
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-[100px]">Unit Type</TableHead>
-            <TableHead className="text-right">Rent Price</TableHead>
-          </TableRow>
-        </TableHeader>
+    <Table className="max-w-[500px]">
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-[100px]">Unit Type</TableHead>
+          <TableHead className="text-right">Rent Price</TableHead>
+        </TableRow>
+      </TableHeader>
 
-        <TableBody>
-          {unitTypes.map((unitType) => (
-            <TableRow key={`${unitType.unitType}-${unitType.rentPrice}`}>
-              <TableCell className="font-medium">{unitType.unitType}</TableCell>
-              <TableCell className="text-right">{unitType.rentPrice}</TableCell>
-              <TableCell className="text-right">
-                <Button
-                  variant={"ghost"}
-                  size={"icon"}
-                  onClick={() => deleteUnitType(unitType)}
-                >
-                  <Trash className="h-4 w-4" />
-                </Button>
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </div>
+      <TableBody>
+        {unitTypes.map((unitType) => (
+          <TableRow key={`${unitType.unitType}-${unitType.rentPrice}`}>
+            <TableCell className="font-medium">{unitType.unitType}</TableCell>
+            <TableCell className="text-right">{unitType.rentPrice}</TableCell>
+            <TableCell className="text-right">
+              <Button
+                variant={"ghost"}
+                size={"icon"}
+                onClick={() => deleteUnitType(unitType)}
+              >
+                <Trash className="h-4 w-4" />
+              </Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
   );
 }

--- a/src/components/pages/error.tsx
+++ b/src/components/pages/error.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { AlertCircle, ArrowLeft } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "~/components/ui/card";
+
+export default function ErrorPage() {
+  const router = useRouter();
+
+  return (
+    <div className="flex h-full items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <AlertCircle className="text-destructive h-6 w-6" />
+            <span>Error Occurred</span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground">
+            We apologize, but something went wrong. Please try again or return
+            to the previous page.
+          </p>
+        </CardContent>
+        <CardFooter className="flex justify-between">
+          <Button
+            variant="outline"
+            onClick={() => router.back()}
+            className="flex items-center gap-2"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Go Back
+          </Button>
+          <Button onClick={() => router.push("/")}>Return Home</Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/ui/back-button.tsx
+++ b/src/components/ui/back-button.tsx
@@ -18,7 +18,7 @@ export function BackButton() {
           onClick={() => router.back()}
           className="cursor-pointer"
         >
-          <ArrowLeft size={48} />
+          <ArrowLeft size={32} />
           <span className="sr-only">Back</span>
         </Button>
       </TooltipTrigger>

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -2,6 +2,7 @@ import { propertyRouter } from "~/server/api/routers/property";
 import { tenantRouter } from "~/server/api/routers/tenant";
 import { unitRouter } from "~/server/api/routers/unit";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
+import { paystackRouter } from "./routers/paystack";
 
 /**
  * This is the primary router for your server.
@@ -12,6 +13,7 @@ export const appRouter = createTRPCRouter({
   property: propertyRouter,
   tenant: tenantRouter,
   unit: unitRouter,
+  paystack: paystackRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/paystack.ts
+++ b/src/server/api/routers/paystack.ts
@@ -1,0 +1,82 @@
+import { TRPCError } from "@trpc/server";
+
+import { env } from "~/env";
+import type { FetchBanksResponse } from "~/lib/validators/paystack";
+import { createTRPCRouter, publicProcedure } from "../trpc";
+
+/** The base URL for the Paystack API */
+const BASE_URL = "https://api.paystack.co";
+
+export const paystackRouter = createTRPCRouter({
+  fetchBanks: publicProcedure.query(async () => {
+    try {
+      const res = await fetch(`${BASE_URL}/bank?country=kenya&currency=KES`, {
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${env.PAYSTACK_SECRET_KEY}`,
+        },
+      });
+
+      if (!res.ok) {
+        const errPayload = (await res.json()) as { message?: string };
+        const errMsg = errPayload.message ?? res.statusText;
+
+        // Map HTTP status codes to appropriate TRPC error codes
+        switch (res.status) {
+          case 401:
+          case 403:
+            throw new TRPCError({
+              code: "UNAUTHORIZED",
+              message: "Invalid Paystack API credentials",
+            });
+          case 404:
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Paystack API endpoint not found",
+            });
+          case 429:
+            throw new TRPCError({
+              code: "TOO_MANY_REQUESTS",
+              message: "Rate limit exceeded for Paystack API",
+            });
+          default:
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: `Paystack API error: ${errMsg}`,
+            });
+        }
+      }
+
+      const result = (await res.json()) as FetchBanksResponse;
+
+      if (!result.data || !Array.isArray(result.data)) {
+        throw new TRPCError({
+          code: "PARSE_ERROR",
+          message: "Invalid response format from Paystack API",
+        });
+      }
+
+      return result.data;
+    } catch (error) {
+      // Re-throw TRPC errors as-is
+      if (error instanceof TRPCError) {
+        throw error;
+      }
+
+      // Handle fetch network errors
+      if (error instanceof TypeError) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to connect to Paystack API",
+        });
+      }
+
+      // Log unexpected errors and throw a generic error
+      console.error("Paystack API error:", error);
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "An unexpected error occurred while fetching banks",
+      });
+    }
+  }),
+});


### PR DESCRIPTION
here, the router has a single route `fetchBanks` and the rest of the changes are changes to the UI to support some error-handling, including a generic error page. The changes were necessary as the new route organization broke the layout for the property creation pages. The layout still needs a lot of work, but I'll prefer handling it in a separate pull request.

The refactoring here should belong to issue #171, but here I'm just doing a stop-gap to fix a build error that involves the `fetchBanks` function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an error page that provides clear messaging and navigation options when an error occurs.
  - Added an API integration to fetch bank data from Paystack, supporting dynamic bank selection.

- **UI Improvements**
  - Updated property creation and unit type pages with improved layout, sticky header, and clearer section headings.
  - Added navigation buttons (BackButton) for easier user navigation.
  - Reduced the size of the back arrow icon for better visual balance.

- **Bug Fixes**
  - Enhanced error handling during bank data fetching, displaying an error page if the fetch fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->